### PR TITLE
Fixes #24

### DIFF
--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/CopyCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/CopyCMD.java
@@ -57,6 +57,7 @@ public class CopyCMD implements Subcommand {
         location.setPitch(originalLocation.getPitch());
         location.setYaw(originalLocation.getYaw());
         data.setLocation(location);
+        data.setLinkedNpcName(null);
 
         final var copy = FancyHolograms.get().getHologramsManager().create(data);
 


### PR DESCRIPTION
Sets the linked NPC name to null for copied holograms, thus allowing them to be properly linked to a new NPC.