### PR TITLE
Add new hologram commands: swapLines, moveUp, moveDown (Closes #49)

### DIFF
--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/HologramType.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/HologramType.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum HologramType {
-    TEXT(Arrays.asList("background", "textshadow", "textalignment", "seethrough", "setline", "removeline", "addline", "insertbefore", "insertafter", "updatetextinterval")),
+    TEXT(Arrays.asList("background", "textshadow", "textalignment", "seethrough", "setline", "removeline", "addline", "insertbefore", "insertafter", "swaplines", "moveup", "movedown", "updatetextinterval")),
     ITEM(List.of("item")),
     BLOCK(List.of("block"));
 

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
@@ -206,9 +206,17 @@ public final class HologramCMD extends Command {
                 }
                 case "brightness" -> Stream.of("block", "sky");
                 case "textalignment" -> Arrays.stream(TextDisplay.TextAlignment.values()).map(Enum::name);
-                case "setline", "removeline" -> {
+                case "setline", "removeline", "swaplines" -> {
                     TextHologramData textData = (TextHologramData) hologram.getData();
                     yield IntStream.range(1, textData.getText().size() + 1).mapToObj(Integer::toString);
+                }
+                case "moveup" -> {
+                    TextHologramData textData = (TextHologramData) hologram.getData();
+                    yield IntStream.range(2, textData.getText().size() + 1).mapToObj(Integer::toString);
+                }
+                case "movedown" -> {
+                    TextHologramData textData = (TextHologramData) hologram.getData();
+                    yield IntStream.range(1, textData.getText().size()).mapToObj(Integer::toString);
                 }
                 case "linkwithnpc" -> {
                     if (!PluginUtils.isFancyNpcsEnabled()) {
@@ -220,6 +228,21 @@ public final class HologramCMD extends Command {
                 case "block" -> Arrays.stream(Material.values()).filter(Material::isBlock).map(Enum::name);
                 case "seethrough" -> Stream.of("true", "false");
                 case "visibility" -> new VisibilityCMD().tabcompletion(sender, hologram, args).stream();
+
+                default -> null;
+            };
+
+            if (suggestions != null) {
+                return suggestions.filter(input -> input.toLowerCase().startsWith(args[3].toLowerCase(Locale.ROOT))).toList();
+            }
+        }
+
+        if(args.length == 5) {
+            final var suggestions = switch (args[2].toLowerCase(Locale.ROOT)) {
+                case "swaplines" -> {
+                    TextHologramData textData = (TextHologramData) hologram.getData();
+                    yield IntStream.range(1, textData.getText().size() + 1).mapToObj(Integer::toString);
+                }
 
                 default -> null;
             };
@@ -336,6 +359,9 @@ public final class HologramCMD extends Command {
             case "removeline" -> new RemoveLineCMD().run(player, hologram, args);
             case "insertbefore" -> new InsertBeforeCMD().run(player, hologram, args);
             case "insertafter" -> new InsertAfterCMD().run(player, hologram, args);
+            case "swaplines" -> new SwapLinesCMD().run(player, hologram, args);
+            case "moveup" -> new MoveUpCMD().run(player, hologram, args);
+            case "movedown" -> new MoveDownCMD().run(player, hologram, args);
             case "textshadow" -> new TextShadowCMD().run(player, hologram, args);
             case "textalignment" -> new TextAlignmentCMD().run(player, hologram, args);
             case "seethrough" -> new SeeThroughCMD().run(player, hologram, args);

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/MoveDownCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/MoveDownCMD.java
@@ -1,0 +1,77 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import com.google.common.primitives.Ints;
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.events.HologramUpdateEvent;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import de.oliver.fancyholograms.commands.HologramCMD;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MoveDownCMD implements Subcommand {
+
+    @Override
+    public List<String> tabcompletion(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        if (!player.hasPermission("fancyholograms.hologram.edit.line.movedown")) {
+            MessageHelper.error(player, "You don't have the required permission to move lines down");
+            return false;
+        }
+
+        if (!(hologram.getData() instanceof TextHologramData textData)) {
+            MessageHelper.error(player, "This command can only be used on text holograms");
+            return false;
+        }
+
+        if (args.length < 4) {
+            MessageHelper.error(player, "Wrong usage: /hologram help");
+            return false;
+        }
+
+        final var parsedIndex = Ints.tryParse(args[3]);
+        final var lines = new ArrayList<>(textData.getText());
+
+        if (parsedIndex == null || parsedIndex < 0 || parsedIndex > lines.size()) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        final var index = parsedIndex - 1;
+
+        if(index < 0 || index + 1 > lines.size() - 1) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        String temp = lines.get(index);
+        lines.set(index, lines.get(index + 1));
+        lines.set(index + 1, temp);
+
+        final var copied = textData.copy(textData.getName());
+        copied.setText(lines);
+
+        if (!HologramCMD.callModificationEvent(hologram, player, copied, HologramUpdateEvent.HologramModification.TEXT)) {
+            return false;
+        }
+
+        textData.setText(copied.getText());
+
+        if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
+            FancyHolograms.get().getHologramStorage().save(hologram);
+        }
+
+        MessageHelper.success(player, "Moved line " + parsedIndex + " down");
+        return true;
+    }
+}

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/MoveUpCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/MoveUpCMD.java
@@ -1,0 +1,77 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import com.google.common.primitives.Ints;
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.events.HologramUpdateEvent;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import de.oliver.fancyholograms.commands.HologramCMD;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MoveUpCMD implements Subcommand {
+
+    @Override
+    public List<String> tabcompletion(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        if (!player.hasPermission("fancyholograms.hologram.edit.line.moveup")) {
+            MessageHelper.error(player, "You don't have the required permission to move lines up");
+            return false;
+        }
+
+        if (!(hologram.getData() instanceof TextHologramData textData)) {
+            MessageHelper.error(player, "This command can only be used on text holograms");
+            return false;
+        }
+
+        if (args.length < 4) {
+            MessageHelper.error(player, "Wrong usage: /hologram help");
+            return false;
+        }
+
+        final var parsedIndex = Ints.tryParse(args[3]);
+
+        if (parsedIndex == null || parsedIndex <= 0) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        final var index = parsedIndex - 1;
+        final var lines = new ArrayList<>(textData.getText());
+
+        if (index >= lines.size() || index - 1 < 0) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        String temp = lines.get(index);
+        lines.set(index, lines.get(index - 1));
+        lines.set(index - 1, temp);
+
+        final var copied = textData.copy(textData.getName());
+        copied.setText(lines);
+
+        if (!HologramCMD.callModificationEvent(hologram, player, copied, HologramUpdateEvent.HologramModification.TEXT)) {
+            return false;
+        }
+
+        textData.setText(copied.getText());
+
+        if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
+            FancyHolograms.get().getHologramStorage().save(hologram);
+        }
+
+        MessageHelper.success(player, "Moved line " + parsedIndex + " up");
+        return true;
+    }
+}

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/SwapLinesCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/SwapLinesCMD.java
@@ -1,0 +1,90 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import com.google.common.primitives.Ints;
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.events.HologramUpdateEvent;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import de.oliver.fancyholograms.commands.HologramCMD;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SwapLinesCMD implements Subcommand {
+
+    @Override
+    public List<String> tabcompletion(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender player, @Nullable Hologram hologram, @NotNull String[] args) {
+        if (!(player.hasPermission("fancyholograms.hologram.edit.line.swap"))) {
+            MessageHelper.error(player, "You don't have the required permission to swap lines on this hologram");
+            return false;
+        }
+
+        if (!(hologram.getData() instanceof TextHologramData textData)) {
+            MessageHelper.error(player, "This command can only be used on text holograms");
+            return false;
+        }
+
+        if (args.length < 5) {
+            MessageHelper.error(player, "Wrong usage: /hologram help");
+            return false;
+        }
+
+        final var parsedIndex1 = Ints.tryParse(args[3]);
+        final var parsedIndex2 = Ints.tryParse(args[4]);
+
+        if (parsedIndex1 == null || parsedIndex2 == null) {
+            MessageHelper.error(player, "Could not parse one or both line numbers");
+            return false;
+        }
+
+        final var lines = new ArrayList<>(textData.getText());
+
+        if (parsedIndex1 < 0 || parsedIndex1 > lines.size() || parsedIndex2 < 0 || parsedIndex2 > lines.size()) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        final var index1 = parsedIndex1 - 1;
+        final var index2 = parsedIndex2 - 1;
+
+        if(index1 == index2) {
+            MessageHelper.error(player, "Cannot swap a line with itself");
+            return false;
+        }
+
+        if(index1 < 0 || index2 < 0) {
+            MessageHelper.error(player, "Invalid line index");
+            return false;
+        }
+
+        String tempLine = lines.get(index1);
+        lines.set(index1, lines.get(index2));
+        lines.set(index2, tempLine);
+
+        final var copied = textData.copy(textData.getName());
+        copied.setText(lines);
+
+        if (!HologramCMD.callModificationEvent(hologram, player, copied, HologramUpdateEvent.HologramModification.TEXT)) {
+            return false;
+        }
+
+        textData.setText(copied.getText());
+
+        if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
+            FancyHolograms.get().getHologramStorage().save(hologram);
+        }
+
+        MessageHelper.success(player, "Swapped lines " + parsedIndex1 + " and " + parsedIndex2);
+        return true;
+    }
+}

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/util/Constants.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/util/Constants.java
@@ -26,6 +26,9 @@ public enum Constants {
             <%primary_color%>- /hologram edit <hologram> removeLine <dark_gray>- <white>Removes a line at the bottom
             <%primary_color%>- /hologram edit <hologram> insertBefore <line number> <text ...> <dark_gray>- <white>Inserts a line before another
             <%primary_color%>- /hologram edit <hologram> insertAfter <line number> <text ...> <dark_gray>- <white>Inserts a line after another
+            <%primary_color%>- /hologram edit <hologram> swapLines <line number> <line number> <dark_gray>- <white>Swap line positions
+            <%primary_color%>- /hologram edit <hologram> moveUp <line number> <line number> <dark_gray>- <white>Move a line up
+            <%primary_color%>- /hologram edit <hologram> moveDown <line number> <line number> <dark_gray>- <white>Move a line down
             <%primary_color%>- /hologram edit <hologram> setLine <line number> <text ...> <dark_gray>- <white>Edits the line
             <%primary_color%>- /hologram edit <hologram> position <dark_gray>- <white>Teleports the hologram to you
             <%primary_color%>- /hologram edit <hologram> moveTo <x> <y> <z> [yaw] [pitch] <dark_gray>- <white>Teleports the hologram to the coordinates


### PR DESCRIPTION
This pull request adds new command capabilities for editing text-based holograms:

- `/hologram edit <name> swaplines <line1> <line2>` – swaps two lines in a hologram.
- `/hologram edit <name> moveup <line>` – moves a line up by one position.
- `/hologram edit <name> movedown <line>` – moves a line down by one position.