### PR TITLE
Add opacity command and default to vanilla background color (Closes #46)

### DIFF
--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/data/TextHologramData.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/data/TextHologramData.java
@@ -145,7 +145,7 @@ public class TextHologramData extends DisplayHologramData {
             default -> TextDisplay.TextAlignment.CENTER;
         };
 
-        background = null;
+        background = Hologram.DEFAULT_BACKGROUND;
         String backgroundStr = section.getString("background", null);
         if (backgroundStr != null) {
             if (backgroundStr.equalsIgnoreCase("transparent")) {
@@ -172,13 +172,14 @@ public class TextHologramData extends DisplayHologramData {
         section.set("update_text_interval", textUpdateInterval);
 
         final String color;
+
         if (background == null) {
             color = null;
         } else if (background == Hologram.TRANSPARENT) {
             color = "transparent";
         } else {
             NamedTextColor named = background.getAlpha() == 255 ? NamedTextColor.namedColor(background.asRGB()) : null;
-            color = named != null ? named.toString() : '#' + Integer.toHexString(background.asARGB());
+            color = named != null ? named.toString() : '#' + String.format("%08X", background.asARGB());
         }
 
         section.set("background", color);

--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/data/TextHologramData.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/data/TextHologramData.java
@@ -21,7 +21,7 @@ public class TextHologramData extends DisplayHologramData {
     public static final int DEFAULT_TEXT_UPDATE_INTERVAL = -1;
 
     private List<String> text;
-    private Color background;
+    private Color background = Hologram.DEFAULT_BACKGROUND;
     private TextDisplay.TextAlignment textAlignment = DEFAULT_TEXT_ALIGNMENT;
     private boolean textShadow = DEFAULT_TEXT_SHADOW_STATE;
     private boolean seeThrough = DEFAULT_SEE_THROUGH;

--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/Hologram.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/Hologram.java
@@ -32,6 +32,7 @@ public abstract class Hologram {
 
     public static final int LINE_WIDTH = 1000;
     public static final Color TRANSPARENT = Color.fromARGB(0);
+    public static final Color DEFAULT_BACKGROUND = Color.fromARGB(64, 0, 0, 0);
     protected static final int MINIMUM_PROTOCOL_VERSION = 762;
 
     protected final @NotNull HologramData data;

--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/HologramType.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/hologram/HologramType.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum HologramType {
-    TEXT(Arrays.asList("background", "textshadow", "textalignment", "seethrough", "setline", "removeline", "addline", "insertbefore", "insertafter", "updatetextinterval")),
+    TEXT(Arrays.asList("background", "opacity", "textshadow", "textalignment", "seethrough", "setline", "removeline", "addline", "insertbefore", "insertafter", "updatetextinterval")),
     ITEM(List.of("item")),
     BLOCK(List.of("block"));
 

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
@@ -200,6 +200,7 @@ public final class HologramCMD extends Command {
 
                     yield colors.stream();
                 }
+                case "opacity" -> Stream.of("0", "0.25", "0.5", "0.75", "1");
                 case "textshadow" -> {
                     TextHologramData textData = (TextHologramData) hologram.getData();
                     yield Stream.of(!textData.hasTextShadow()).map(Object::toString);
@@ -331,6 +332,7 @@ public final class HologramCMD extends Command {
 
             // text data
             case "background" -> new BackgroundCMD().run(player, hologram, args);
+            case "opacity" -> new OpacityCMD().run(player, hologram, args);
             case "addline" -> new AddLineCMD().run(player, hologram, args);
             case "setline" -> new SetLineCMD().run(player, hologram, args);
             case "removeline" -> new RemoveLineCMD().run(player, hologram, args);

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/BackgroundCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/BackgroundCMD.java
@@ -42,7 +42,7 @@ public class BackgroundCMD implements Subcommand {
         final Color background;
 
         if (color.equals("reset") || color.equals("default")) {
-            background = null;
+            background = Hologram.DEFAULT_BACKGROUND;
         } else {
             if (color.equals("transparent")) {
                 background = Hologram.TRANSPARENT;

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/OpacityCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/OpacityCMD.java
@@ -1,0 +1,80 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.events.HologramUpdateEvent;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import de.oliver.fancyholograms.commands.HologramCMD;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.Color;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class OpacityCMD implements Subcommand {
+
+    @Override
+    public List<String> tabcompletion(@NotNull CommandSender sender, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender sender, @Nullable Hologram hologram, @NotNull String[] args) {
+        if (!sender.hasPermission("fancyholograms.hologram.edit.opacity")) {
+            MessageHelper.error(sender, "You don't have the required permission to change the opacity of a hologram.");
+            return false;
+        }
+
+        if (!(hologram.getData() instanceof TextHologramData textData)) {
+            MessageHelper.error(sender, "This command can only be used on text holograms.");
+            return false;
+        }
+
+        if (args.length < 4) {
+            MessageHelper.error(sender, "Wrong usage: /hologram help");
+            return false;
+        }
+
+        float opacity;
+
+        try {
+            opacity = Float.parseFloat(args[3]);
+        } catch (NumberFormatException e) {
+            MessageHelper.error(sender, "Opacity must be a number between 0 and 1.");
+            return false;
+        }
+
+        if (opacity < 0 || opacity > 1) {
+            MessageHelper.error(sender, "Opacity must be between 0 and 1.");
+            return false;
+        }
+
+        Color background = textData.getBackground();
+
+        int alpha = (int) (opacity * 255);
+        if (background.getAlpha() == alpha) {
+            MessageHelper.warning(sender, "This hologram already has this opacity.");
+            return false;
+        }
+
+        Color updated = background.setAlpha(alpha);
+        final var copied = textData.copy(textData.getName());
+        copied.setBackground(updated);
+
+        if (!HologramCMD.callModificationEvent(hologram, sender, copied, HologramUpdateEvent.HologramModification.BACKGROUND)) {
+            return false;
+        }
+
+        textData.setBackground(updated);
+
+        if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
+            FancyHolograms.get().getHologramStorage().save(hologram);
+        }
+
+        MessageHelper.success(sender, "Changed hologram opacity to " + opacity);
+        return true;
+    }
+}

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/OpacityCMD.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/commands/hologram/OpacityCMD.java
@@ -54,7 +54,8 @@ public class OpacityCMD implements Subcommand {
 
         Color background = textData.getBackground();
 
-        int alpha = (int) (opacity * 255);
+        int alpha = opacity == 0 ? 0 : Math.round(opacity * (255 - 26) + 26);
+
         if (background.getAlpha() == alpha) {
             MessageHelper.warning(sender, "This hologram already has this opacity.");
             return false;

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/util/Constants.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/util/Constants.java
@@ -33,6 +33,7 @@ public enum Constants {
             <%primary_color%>- /hologram edit <hologram> scale <factor> <dark_gray>- <white>Changes the scale of the hologram
             <%primary_color%>- /hologram edit <hologram> billboard <center|fixed|horizontal|vertical> <factor> <dark_gray>- <white>Changes the billboard of the hologram
             <%primary_color%>- /hologram edit <hologram> background <color> <dark_gray>- <white>Changes the background of the hologram
+            <%primary_color%>- /hologram edit <hologram> opacity <opacity> <dark_gray>- <white>Changes the background opacity of the hologram
             <%primary_color%>- /hologram edit <hologram> textShadow <true|false> <dark_gray>- <white>Enables/disables the text shadow
             <%primary_color%>- /hologram edit <hologram> textAlignment <alignment> <dark_gray>- <white>Sets the text alignment
             <%primary_color%>- /hologram edit <hologram> seeThrough <true|false> <dark_gray>- <white>Enables/disables whether the text can be seen through blocks


### PR DESCRIPTION
This pull request introduces new command capabilities for editing text-based holograms:

- `/hologram edit <name> opacity <opacity>` – sets the background opacity of the hologram (range: 0–1).
- Defaults to the vanilla text display background color (`Color.fromARGB(64, 0, 0, 0)`) when no background is explicitly set, replacing previous `null` behavior.

Additionally, this PR fixes an issue where the alpha channel was lost when loading hologram data from the configuration.