### PR TITLE
fancynpcs: fix placeholder skins not refreshing

### DIFF
--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
@@ -116,7 +116,7 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
         config.setInlineComments("autosave_interval", List.of("The interval at which autosave is performed in minutes."));
 
         npcUpdateInterval = (int) ConfigHelper.getOrDefault(config, "npc_update_interval", 60);
-        config.setInlineComments("npc_update_skin_interval", List.of("The interval at which the NPC is updated (in seconds). Only if the skin or displayName is a placeholder."));
+        config.setInlineComments("npc_update_interval", List.of("The interval at which the NPC is updated (in seconds). Only if the skin or displayName is a placeholder."));
 
         npcUpdateVisibilityInterval = (int) ConfigHelper.getOrDefault(config, "npc_update_visibility_interval", 20);
         config.setInlineComments("npc_update_visibility_interval", List.of("The interval at which the NPC visibility is updated (in ticks)."));


### PR DESCRIPTION
## 📋 Description

Fixed NPCs never updating their skins and display name when set from a placeholder. I tested these changes *briefly* and they work as expected. One thing I noticed that should be fixed, but is out-of-scope for this PR, is NPC swinging their hand each time it is refreshed - even when display name or skin did not change.

Needs further testing, I attached compiled `.jar` file. (It must be packed as `.zip` due to GitHub limitations)
[FancyNpcs-2.7.0.zip](https://github.com/user-attachments/files/21442434/FancyNpcs-2.7.0.zip)

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [ ] I have added necessary documentation (if applicable)
- [ ] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

- Fixed NPCs never updating their skins and display names when these are set from a placeholder.
- Fixed comment not generating for `npc_update_interval` config option.

---

## 🧪 How to Test

Create NPC and set it's skin to a placeholder. In my testing, I was using [ConditionalText](https://modrinth.com/plugin/conditionaltext) with following placeholder:
  ```yml
  skin-test:
    placeholder: "%math_1%"
    rules:
      - "==1.000;Name1"
      - "==2.000;Name2"
      - "==3.000;Name3"
      - "==4.000;Name4"
      - "==5.000;Name5"
      - "==6.000;Name5"
      - "Name6"
  ```
  Replace `NameX` with real data - you can find names on **[namemc.com](https://namemc.com/)**. To change the placeholder output, change `%math_1%` to eg. `%math_2%` and reload the plugin using `/conditionaltext reload`. This config creates `%conditionaltext_skin-text%` placeholder that can be used in both, display name and skin.
