### PR TITLE
Fix ItemHologramData JSON serialization using Base64 to prevent corrupted item data

### DIFF
--- a/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/storage/json/JsonAdapter.java
+++ b/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/storage/json/JsonAdapter.java
@@ -13,6 +13,8 @@ import org.bukkit.entity.Display;
 import org.bukkit.inventory.ItemStack;
 import org.joml.Vector3f;
 
+import java.util.Base64;
+
 public class JsonAdapter {
 
     public static JsonHologramData hologramDataToJson(com.fancyinnovations.fancyholograms.api.data.HologramData data) {
@@ -78,7 +80,7 @@ public class JsonAdapter {
 
     public static JsonItemHologramData itemHologramDataToJson(com.fancyinnovations.fancyholograms.api.data.ItemHologramData data) {
         return new JsonItemHologramData(
-                new String(data.getItemStack().serializeAsBytes())
+                Base64.getEncoder().encodeToString(data.getItemStack().serializeAsBytes())
         );
     }
 
@@ -178,7 +180,8 @@ public class JsonAdapter {
 
             case ITEM ->
                     new com.fancyinnovations.fancyholograms.api.data.ItemHologramData(data.hologram_data().name(), loc)
-                            .setItemStack(ItemStack.deserializeBytes(data.item_data().item().getBytes())) // item data
+                            //.setItemStack(ItemStack.deserializeBytes(data.item_data().item().getBytes())) // item data
+                            .setItemStack(ItemStack.deserializeBytes(Base64.getDecoder().decode(data.item_data().item())))
                             .setBillboard(data.display_data().billboard()) // display data
                             .setScale(scale)
                             .setTranslation(translation)


### PR DESCRIPTION
## 📋 Description

Fixes a critical bug where ItemHologramData fails to save correctly in the .json file due to raw binary being written instead of Base64. This caused crashes and illegal characters (\u001f, �, etc.) in hologram JSON.

The fix encodes ItemStack bytes with Base64 when saving, and decodes them when loading, ensuring hologram JSON is always valid.

## ✅ Checklist

- ✅ My code follows the project's coding style and guidelines
- ✅ I have tested my changes locally and they work as expected
- ✅ I have added necessary documentation (N/A – internal fix only)
- ❌ I have linked related issues (No existing GitHub issue – discovered during testing)
- ✅ I have rebased/merged with the latest `main` branch

## 🔍 Changes

- Changed itemHologramDataToJson to use Base64.getEncoder().encodeToString(...)
- Changed fromJson for ItemHologramData to use Base64.getDecoder().decode(...)
- Prevents invalid characters in .json and fixes Illegal base64 character crashes

---

## 🔦 Issue highlight:
before (broken):
`"\u001f�\b\u0000\u0000\u0000\u0000\u0000\u0000�\u0005��\t�0\f\u0005ЯE\u0010����xv\u0006oRBS1�&���}o\u0001\u0012֓���]L��1\nco��8=q�P3�����ɛy�T��\u00000�\u0007�^��F\u0000\u0000\u0000"`

after (fixed):
`"H4sIAAAAAAAA/0WOMQ7CMBAEF6wgMA0FHeIjlIg30CHL2Bdiyfah86XgFzyG/wGpMvXMai1gsL149VeSlrgCu9sayxRxLKlSEN/rKZPXgcQNLI2cl8Ji0AUeqwJYWNjA5cmVqjaL/RzGF0UXOE++kccd3/SBxWE2wtiUiyscKbv4/7HBqs/stXXT9PmNiR+zY1CZpwAAAA=="`

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Spawn an item hologram in-game.
2. Inspect the .json file under plugins/FancyHolograms/.
3. Confirm that the item_data.item field contains Base64 text, no illegal characters.
4. Ensure the hologram loads correctly both for newly created holograms and existing migrated holograms.
