### PR TITLE
fancyholograms v3: Fix hologram updates only applying to first player

### DIFF
--- a/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/controller/HologramControllerImpl.java
+++ b/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/controller/HologramControllerImpl.java
@@ -125,21 +125,24 @@ public class HologramControllerImpl implements HologramController {
             for (final var hologram : FancyHologramsPlugin.get().getRegistry().getAll()) {
                 HologramData data = hologram.getData();
 
+                if (!data.hasChanges()) {
+                    continue;
+                }
+
                 for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-                    if (data.hasChanges()) {
-                        FoliaSchedulerHelper.playerScheduler(onlinePlayer, () -> {
-                            if (!shouldSeeHologram(hologram, onlinePlayer)) {
-                                return;
-                            }
+                    FoliaSchedulerHelper.playerScheduler(onlinePlayer, () -> {
+                        if (!shouldSeeHologram(hologram, onlinePlayer)) {
+                            return;
+                        }
 
-                            hologram.updateFor(onlinePlayer);
-                            data.setHasChanges(false);
+                        hologram.updateFor(onlinePlayer);
+                    });
+                }
 
-                            if (data instanceof TextHologramData) {
-                                updateTimes.put(hologram.getData().getName(), time);
-                            }
-                        });
-                    }
+                data.setHasChanges(false);
+
+                if (data instanceof TextHologramData) {
+                    updateTimes.put(hologram.getData().getName(), time);
                 }
             }
         }, 50, 1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## 📋 Description

Please include a summary of the changes and the related issue(s).  
What is this PR solving? Why is it needed?

## ✅ Checklist

- [X] My code follows the project's coding style and guidelines
- [X] I have tested my changes locally and they work as expected
- [ ] I have added necessary documentation (if applicable)
- [ ] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [X] I have rebased/merged with the latest `main` branch

## 🔍 Changes

## What does this PR do?

Fixes a bug where hologram content changes were only sent to the **first** online player, leaving every other viewer with stale text.

## Root cause

In `HologramControllerImpl.initUpdateTask()`, the `data.setHasChanges(false)` call was placed **inside** the per-player loop (and inside the `FoliaSchedulerHelper.playerScheduler` callback).

Since `FoliaSchedulerHelper.playerScheduler` runs **synchronously on Paper/Spigot**, the flag was cleared after the first player was updated, so the `if (data.hasChanges())` check failed for all subsequent players.

This was introduced in `2e7c51ce` ("Refactor visibility management"). The v2 implementation (`HologramManagerImpl`) still has `setHasChanges(false)` correctly placed *after* updating all viewers.

## Changes

- Moved `data.setHasChanges(false)` and the `updateTimes` bookkeeping out of the player loop so the flag is cleared only once, after every viewer has been updated.
- Hoisted the `hasChanges` check above the loop to avoid redundant iteration.

## Impact

- `refreshHologram()`/text updates now propagate to **all** online players instead of only the first.
- Behavior on Folia is unchanged (callbacks are scheduled before the flag is cleared).

## Related

- MineBlocks and ExcellentCrates both rely on this update path via `setText()` + `refreshHologram()`.